### PR TITLE
Fix/role permission registration

### DIFF
--- a/src/main/java/com/accolite/pru/health/AuthApp/model/Role.java
+++ b/src/main/java/com/accolite/pru/health/AuthApp/model/Role.java
@@ -43,6 +43,10 @@ public class Role {
 
 	}
 
+	public boolean isAdminRole(){
+		return null != this && this.role.equals(RoleName.ROLE_ADMIN);
+	}
+
 	public Long getId() {
 		return id;
 	}

--- a/src/main/java/com/accolite/pru/health/AuthApp/service/UserService.java
+++ b/src/main/java/com/accolite/pru/health/AuthApp/service/UserService.java
@@ -106,14 +106,13 @@ public class UserService {
 	}
 
 	/**
-	 * Performs a quick check to see what roles the new user could benefit from
+	 * Performs a quick check to see what roles the new user could be assigned to.
 	 * @return list of roles for the new user
 	 */
-	private Set<Role> getRolesForNewUser(Boolean isAdmin) {
+	private Set<Role> getRolesForNewUser(Boolean isToBeMadeAdmin) {
 		Set<Role> newUserRoles = new HashSet<>(roleService.findAll());
-		Role adminRole = new Role(RoleName.ROLE_ADMIN);
-		if (!isAdmin) {
-			newUserRoles.remove(adminRole);
+		if (!isToBeMadeAdmin){
+		newUserRoles.removeIf(Role::isAdminRole);
 		}
 		logger.info("Setting user roles: " + newUserRoles);
 		return newUserRoles;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -9,8 +9,9 @@ spring.datasource.password=
 spring.datasource.testWhileIdle=true
 spring.datasource.validationQuery=SELECT 1
 
-#JPA properties
-spring.jpa.hibernate.ddl-auto=none
+#JPA properties. Using ddl-auto = create will drop schema every-time.
+#Choose the correct property based on development / production role.
+spring.jpa.hibernate.ddl-auto=create
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL5InnoDBDialect
 spring.datasource.initialization-mode=always
 spring.jpa.properties.hibernate.format_sql=true

--- a/src/main/resources/mail.properties
+++ b/src/main/resources/mail.properties
@@ -1,8 +1,8 @@
 #Mail properties
 spring.mail.default-encoding=UTF-8
 spring.mail.host=smtp.gmail.com
-spring.mail.username=accolite.pru.cep@gmail.com
-spring.mail.password=accolitecep
+spring.mail.username=your@email.com
+spring.mail.password=your-email-password
 spring.mail.port=587
 spring.mail.protocol=smtp
 spring.mail.debug=true


### PR DESCRIPTION
## Summary

| PR Status  | Type  | Impact level |
| :---: | :---: | :---: |
| Ready  | Bug | High |

## Description
It was reported in mail by a user, that during registration, the user was getting admin privileges even when the flag was set to false.

<!--- Describe your changes in detail -->

## Motivation & Context

It was reported by @Joan Colmenero

```
Hello Aman!

I'm looking into the code, and I'm trying to create a findAllBy to get all of those users that have been registered as Admin, I've created one with the flag in false, but on my database I still see that that guy has the same authority than the admin one, please could you tell me how do I fix this? 
```
![image](https://user-images.githubusercontent.com/12872673/54866027-0fad6b00-4d95-11e9-85f8-2a9ff58e6cc6.png)
```
I created two users, one with registerAsAdmin true(1) and other registerAsAdmin false(2) and as you can see both have both roles... 
```

The bug arose because I was removing admin role from the set of roles by creating a new object instead of comparing their enums.
Set removal on a new object didn't work obviously. Fixed by checking on the enum type instead.

## Why was this change not caught
It was a miss from my side. 
This project lacks UT's and I plan to add them shortly.
Thanks @Joan Colmenero for reporting the bug
