### PR TITLE
Bug/Multi Device. Lookup device by User ID and 'deviceId'

### DIFF
--- a/src/main/java/com/accolite/pru/health/AuthApp/repository/UserDeviceRepository.java
+++ b/src/main/java/com/accolite/pru/health/AuthApp/repository/UserDeviceRepository.java
@@ -26,5 +26,5 @@ public interface UserDeviceRepository extends JpaRepository<UserDevice, Long> {
 
     Optional<UserDevice> findByRefreshToken(RefreshToken refreshToken);
 
-    Optional<UserDevice> findByUserId(Long userId);
+    Optional<UserDevice> findByUserIdAndDeviceId(Long userId, String userDeviceId);
 }

--- a/src/main/java/com/accolite/pru/health/AuthApp/service/AuthService.java
+++ b/src/main/java/com/accolite/pru/health/AuthApp/service/AuthService.java
@@ -189,13 +189,13 @@ public class AuthService {
 
     /**
      * Creates and persists the refresh token for the user device. If device exists
-     * already, we don't care. Unused devices with expired tokens should be cleaned
-     * with a cron job. The generated token would be encapsulated within the jwt.
-     * Remove the existing refresh token as the old one should not remain valid.
+     * already, we recreate the refresh token. Unused devices with expired tokens
+     * should be cleaned externally.
      */
     public Optional<RefreshToken> createAndPersistRefreshTokenForDevice(Authentication authentication, LoginRequest loginRequest) {
         User currentUser = (User) authentication.getPrincipal();
-        userDeviceService.findByUserId(currentUser.getId())
+        String deviceId = loginRequest.getDeviceInfo().getDeviceId();
+        userDeviceService.findDeviceByUserId(currentUser.getId(), deviceId)
                 .map(UserDevice::getRefreshToken)
                 .map(RefreshToken::getId)
                 .ifPresent(refreshTokenService::deleteById);

--- a/src/main/java/com/accolite/pru/health/AuthApp/service/UserDeviceService.java
+++ b/src/main/java/com/accolite/pru/health/AuthApp/service/UserDeviceService.java
@@ -36,8 +36,8 @@ public class UserDeviceService {
     /**
      * Find the user device info by user id
      */
-    public Optional<UserDevice> findByUserId(Long userId) {
-        return userDeviceRepository.findByUserId(userId);
+    public Optional<UserDevice> findDeviceByUserId(Long userId, String deviceId) {
+        return userDeviceRepository.findByUserIdAndDeviceId(userId, deviceId);
     }
 
     /**

--- a/src/main/java/com/accolite/pru/health/AuthApp/service/UserService.java
+++ b/src/main/java/com/accolite/pru/health/AuthApp/service/UserService.java
@@ -124,11 +124,11 @@ public class UserService {
 
     /**
      * Log the given user out and delete the refresh token associated with it. If no device
-     * id is found matching the database for the given user, throw a log out exception.
+     * id is found matching the database for this user, throw a log out exception.
      */
     public void logoutUser(@CurrentUser CustomUserDetails currentUser, LogOutRequest logOutRequest) {
         String deviceId = logOutRequest.getDeviceInfo().getDeviceId();
-        UserDevice userDevice = userDeviceService.findByUserId(currentUser.getId())
+        UserDevice userDevice = userDeviceService.findDeviceByUserId(currentUser.getId(), deviceId)
                 .filter(device -> device.getDeviceId().equals(deviceId))
                 .orElseThrow(() -> new UserLogoutException(logOutRequest.getDeviceInfo().getDeviceId(), "Invalid device Id supplied. No matching device found for the given user "));
 


### PR DESCRIPTION
## Summary
| PR Status  | Type  | Impact level |
| :---: | :---: | :---: |
| Ready  | Bug | High |

## Description
This PR fixes #39 

- Use both "device ID" and "user ID" to look up existing device for the user, otherwise the device ID is basically a no-op and the multi device login / logout is pointless. Thanks to @WoodySide for figuring out the bug.

## Motivation & Context
- Logging in through multiple devices didn't really create a new device. This is because the logic for recreating the device token only worked with the "user ID" and not the "user ID and device ID" pair. 
 
## How was this tested
- Tested that multi device login now sets the right device context. If you login from the same device, it sets the right refresh token

Before
![image](https://user-images.githubusercontent.com/12872673/146644050-0ec309d3-01d6-45bb-9ff5-41a752de137c.png)

After

![image](https://user-images.githubusercontent.com/12872673/146644043-95ff6c91-6c06-41e0-a2f2-b0919a2aec11.png)

After D1 logout
![image](https://user-images.githubusercontent.com/12872673/146644093-c8a74947-6f7a-4205-948f-9bf15d18faef.png)
